### PR TITLE
Fix annotations

### DIFF
--- a/xbrl_parser/helper/xml_parser.py
+++ b/xbrl_parser/helper/xml_parser.py
@@ -6,7 +6,7 @@ It is used by the different parsing modules.
 import xml.etree.ElementTree as ET
 
 
-def parse_file(path) -> ET:
+def parse_file(path: str) -> ET:
     """
     Parses a file, returns the Root element with an attribute 'ns_map' containing the prefix - namespaces map
     @return:

--- a/xbrl_parser/instance.py
+++ b/xbrl_parser/instance.py
@@ -8,6 +8,7 @@ import abc
 import logging
 import sys
 import time
+from typing import List
 import xml.etree.ElementTree as ET
 from datetime import date, datetime
 from time import strptime
@@ -62,7 +63,7 @@ class AbstractContext(abc.ABC):
     def __init__(self, xml_id: str, entity: str) -> None:
         self.xml_id: str = xml_id
         self.entity: str = entity
-        self.segments: [ExplicitMember] = []
+        self.segments: List[ExplicitMember] = []
 
 
 class InstantContext(AbstractContext):
@@ -225,14 +226,14 @@ class XbrlInstance(abc.ABC):
     Class representing a xbrl instance file
     """
 
-    def __init__(self, url: str, taxonomy: TaxonomySchema, facts: [AbstractFact], context_map: dict,
+    def __init__(self, url: str, taxonomy: TaxonomySchema, facts: List[AbstractFact], context_map: dict,
                  unit_map: dict) -> None:
         """
         :param taxonomy: taxonomy file that the instance file references (via link:schemaRef)
         :param facts: array of all facts that the instance contains
         """
         self.taxonomy: TaxonomySchema = taxonomy
-        self.facts: [AbstractFact] = facts
+        self.facts: List[AbstractFact] = facts
         self.instance_url = url
         self.context_map: dict = context_map
         self.unit_map: dict = unit_map
@@ -290,7 +291,7 @@ def parse_xbrl(instance_path: str, cache: HttpCache, instance_url: str or None =
     unit_dir = _parse_unit_elements(root.findall('xbrli:unit', NAME_SPACES))
 
     # parse facts
-    facts: [AbstractFact] = []
+    facts: List[AbstractFact] = []
     for fact_elem in root:
         # skip contexts and units
         if 'context' in fact_elem.tag or 'unit' in fact_elem.tag or 'schemaRef' in fact_elem.tag:
@@ -393,8 +394,8 @@ def parse_ixbrl(instance_path: str, cache: HttpCache, instance_url: str or None 
     unit_dir = _parse_unit_elements(xbrl_resources.findall('xbrli:unit', NAME_SPACES))
 
     # parse facts
-    facts: [AbstractFact] = []
-    fact_elements: [ET.Element] = root.findall('.//ix:nonFraction', ns_map) + root.findall('.//ix:nonNumeric', ns_map)
+    facts: List[AbstractFact] = []
+    fact_elements: List[ET.Element] = root.findall('.//ix:nonFraction', ns_map) + root.findall('.//ix:nonNumeric', ns_map)
     for fact_elem in fact_elements:
         # check fi the fact actually has data in it
         if fact_elem.text is None or len(fact_elem.text.strip()) == 0:
@@ -489,7 +490,7 @@ def _extract_ixbrl_value(fact_elem: ET.Element) -> float or str:
     return raw_value
 
 
-def _parse_context_elements(context_elements: [ET.Element], ns_map: dict, taxonomy: TaxonomySchema) -> dict:
+def _parse_context_elements(context_elements: List[ET.Element], ns_map: dict, taxonomy: TaxonomySchema) -> dict:
     """
     Parses all context elements from the instance file and stores them into a dictionary with the
     context id as key
@@ -545,7 +546,7 @@ def _parse_context_elements(context_elements: [ET.Element], ns_map: dict, taxono
     return context_dict
 
 
-def _parse_unit_elements(unit_elements: [ET.Element]) -> dict:
+def _parse_unit_elements(unit_elements: List[ET.Element]) -> dict:
     """
     Parses all unit elements from the instance file and stores them into a dictionary with the
     unit id as key

--- a/xbrl_parser/linkbase.py
+++ b/xbrl_parser/linkbase.py
@@ -8,6 +8,7 @@ reference linkbase: ref
 """
 import abc
 import os
+from typing import List
 import xml.etree.ElementTree as ET
 from abc import ABC
 from enum import Enum
@@ -265,7 +266,7 @@ class LabelArc(AbstractArcElement):
 
     """
 
-    def __init__(self, from_locator, order: int, labels: [Label]) -> None:
+    def __init__(self, from_locator, order: int, labels: List[Label]) -> None:
         """
         @type from_locator: Locator
         @param labels: Array of label objects, the arc is pointing to
@@ -311,9 +312,9 @@ class Locator:
         # This array stores the locators that that are connected with this locator via a label arc, there
         # the current locator was in the to attribute. This array is only used for finding the root locators (the locators
         # that have no parents)
-        self.parents: [Locator] = []
+        self.parents: List[Locator] = []
         # This array stores all the labelArcs that reference this locator in the "from" attribute
-        self.children: [AbstractArcElement] = []
+        self.children: List[AbstractArcElement] = []
 
     def __str__(self) -> str:
         return "{} with {} children".format(self.name, len(self.children))
@@ -350,7 +351,7 @@ class ExtendedLink:
 
     """
 
-    def __init__(self, role: str, elr_id: str or None, root_locators: [Locator]) -> None:
+    def __init__(self, role: str, elr_id: str or None, root_locators: List[Locator]) -> None:
         """
         @param role: role of the extended link element
         @param elr_id: the link to the extended Link role (as defined in the schema file)
@@ -360,7 +361,7 @@ class ExtendedLink:
         """
         self.role: str = role
         self.elr_id: str or None = elr_id
-        self.root_locators: [Locator] = root_locators
+        self.root_locators: List[Locator] = root_locators
 
     def to_dict(self) -> dict:
         """
@@ -394,7 +395,7 @@ class Linkbase:
         @type extended_links: [ExtendedDefinitionLink] or [ExtendedCalculationLink] or [ExtendedPresentationLink] or
                                 [ExtendedLabelArc]
         """
-        self.extended_links: [ExtendedLink] = extended_links
+        self.extended_links: List[ExtendedLink] = extended_links
         self.type = linkbase_type
 
     def to_dict(self) -> dict:
@@ -449,7 +450,7 @@ def parse_linkbase(linkbase_path: str, linkbase_type: LinkbaseType) -> Linkbase:
 
     # Loop over all definition/calculation/presentation/label links.
     # Each extended link contains the locators and the definition arc's
-    extended_links: [ExtendedLink] = []
+    extended_links: List[ExtendedLink] = []
 
     # figure out if we want to search for definitionLink, calculationLink, presentationLink or labelLink
     # figure out for what type of arcs we are searching; definitionArc, calculationArc, presentationArc or labelArc

--- a/xbrl_parser/taxonomy.py
+++ b/xbrl_parser/taxonomy.py
@@ -8,6 +8,7 @@ Taxonomy schemas can import multiple different taxonomy schemas.
 """
 import logging
 import os
+from typing import List
 import xml.etree.ElementTree as ET
 from functools import lru_cache
 
@@ -108,12 +109,12 @@ class TaxonomySchema:
         4. Overriding of resources:
             The Label Linkbase of this taxonomy can override the labels of the base taxonomy!
         """
-        self.imports: [TaxonomySchema] = []
-        self.link_roles: [ExtendedLinkRole] = []
-        self.lab_linkbases: [Linkbase] = []
-        self.def_linkbases: [Linkbase] = []
-        self.cal_linkbases: [Linkbase] = []
-        self.pre_linkbases: [Linkbase] = []
+        self.imports: List[TaxonomySchema] = []
+        self.link_roles: List[ExtendedLinkRole] = []
+        self.lab_linkbases: List[Linkbase] = []
+        self.def_linkbases: List[Linkbase] = []
+        self.cal_linkbases: List[Linkbase] = []
+        self.pre_linkbases: List[Linkbase] = []
 
         self.schema_url = schema_url
         self.namespace = namespace
@@ -225,7 +226,7 @@ def parse_taxonomy(schema_path: str, cache: HttpCache, schema_url: str or None =
     target_ns = root.attrib['targetNamespace']
     taxonomy: TaxonomySchema = TaxonomySchema(schema_url if schema_url else schema_path, target_ns)
 
-    import_elements: [ET.Element] = root.findall('xsd:import', NAME_SPACES)
+    import_elements: List[ET.Element] = root.findall('xsd:import', NAME_SPACES)
 
     for import_element in import_elements:
         import_uri = import_element.attrib['schemaLocation']
@@ -243,7 +244,7 @@ def parse_taxonomy(schema_path: str, cache: HttpCache, schema_url: str or None =
             import_path = resolve_uri(schema_path, import_uri)
             taxonomy.imports.append(parse_taxonomy(import_path, cache))
 
-    role_type_elements: [ET.Element] = root.findall('xsd:annotation/xsd:appinfo/link:roleType', NAME_SPACES)
+    role_type_elements: List[ET.Element] = root.findall('xsd:annotation/xsd:appinfo/link:roleType', NAME_SPACES)
     # parse ELR's
     for elr in role_type_elements:
         elr_definition = elr.find(LINK_NS + 'definition')
@@ -274,7 +275,7 @@ def parse_taxonomy(schema_path: str, cache: HttpCache, schema_url: str or None =
         taxonomy.concepts[concept.xml_id] = concept
         taxonomy.name_id_map[concept.name] = concept.xml_id
 
-    linkbase_ref_elements: [ET.Element] = root.findall('xsd:annotation/xsd:appinfo/link:linkbaseRef', NAME_SPACES)
+    linkbase_ref_elements: List[ET.Element] = root.findall('xsd:annotation/xsd:appinfo/link:linkbaseRef', NAME_SPACES)
     for linkbase_ref in linkbase_ref_elements:
         linkbase_uri = linkbase_ref.attrib[XLINK_NS + 'href']
         role = linkbase_ref.attrib[XLINK_NS + 'role'] if XLINK_NS + 'role' in linkbase_ref.attrib else None


### PR DESCRIPTION
As stated from https://www.python.org/dev/peps/pep-0526/ to create List annotations the right way of doing it is List[int] = []
However from python 3.9 onwards, list[int] = [] is also accepted