### PR TITLE
[speedup] namespace->taxonomy look up recursion replaced with fast LUT

### DIFF
--- a/tests/test_local_taxonomy.py
+++ b/tests/test_local_taxonomy.py
@@ -3,10 +3,11 @@ This unittest tests the parsing of locally saved taxonomies
 """
 import sys
 import unittest
-from xbrl.cache import HttpCache
-from xbrl.taxonomy import parse_taxonomy, TaxonomySchema
 import logging
 
+from xbrl.cache import HttpCache
+from xbrl.taxonomy import parse_taxonomy, TaxonomySchema
+from xbrl.helper.uri_helper import normalise_uri_dict, normalise_uri
 
 class TaxonomySchemaTest(unittest.TestCase):
     """
@@ -23,7 +24,11 @@ class TaxonomySchemaTest(unittest.TestCase):
         # extension_schema_path: str = './data/example.xsd'
         tax: TaxonomySchema = parse_taxonomy(extension_schema_path, cache)
         print(tax)
-        srt_tax: TaxonomySchema = tax.get_taxonomy('http://fasb.org/srt/2020-01-31')
+
+        ns_to_taxonomy_LUT: dict = tax.get_taxonomy_LUT(dict())
+        ns_to_taxonomy_LUT = normalise_uri_dict(ns_to_taxonomy_LUT)
+        srt_tax: TaxonomySchema = ns_to_taxonomy_LUT.get(normalise_uri('http://fasb.org/srt/2020-01-31'), None)
+
         self.assertTrue(srt_tax)
         self.assertEqual(len(srt_tax.concepts), 489)
 

--- a/tests/test_remote_taxonomy.py
+++ b/tests/test_remote_taxonomy.py
@@ -8,6 +8,8 @@ import logging
 import sys
 from xbrl.cache import HttpCache
 from xbrl.taxonomy import TaxonomySchema, parse_taxonomy_url
+from xbrl.helper.uri_helper import normalise_uri_dict, normalise_uri
+
 from tests.utils import get_bot_header
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
@@ -28,7 +30,11 @@ class RemoteTaxonomyTest(unittest.TestCase):
         schema_url: str = 'https://www.sec.gov/Archives/edgar/data/320193/000032019321000010/aapl-20201226.xsd'
         tax: TaxonomySchema = parse_taxonomy_url(schema_url, cache)
         self.assertEqual(len(tax.concepts), 65)
-        us_gaap_tax: TaxonomySchema = tax.get_taxonomy('http://fasb.org/us-gaap/2020-01-31')
+        
+        ns_to_taxonomy_LUT: dict = tax.get_taxonomy_LUT(dict())
+        ns_to_taxonomy_LUT = normalise_uri_dict(ns_to_taxonomy_LUT)
+        us_gaap_tax: TaxonomySchema = ns_to_taxonomy_LUT.get(normalise_uri('http://fasb.org/us-gaap/2020-01-31'), None)
+
         self.assertEqual(len(us_gaap_tax.concepts), 17281)
         self.assertEqual(len(tax.concepts['aapl_MacMember'].labels), 3)
 

--- a/xbrl/helper/uri_helper.py
+++ b/xbrl/helper/uri_helper.py
@@ -4,6 +4,8 @@ Module containing functions for creating and resolving uri's
 import os
 import re
 
+# precompiled for speed https://stackoverflow.com/questions/1276764/stripping-everything-but-alphanumeric-chars-from-a-string-in-python
+pattern = re.compile('[\W]+')
 
 def resolve_uri(dir_uri: str, relative_uri: str) -> str:
     """
@@ -54,6 +56,14 @@ def resolve_uri(dir_uri: str, relative_uri: str) -> str:
 
     return '/'.join(url_parts)
 
+def normalise_uri(uri: str) -> str:
+    """ drop protocol from uri, and any non a-z chars for easy comparison """
+    return pattern.sub('', uri.split('://')[-1])
+
+def normalise_uri_dict(dict_in: dict) -> dict:
+    for k,v in dict_in.copy().items():
+        dict_in[normalise_uri(k)] = dict_in.pop(k)
+    return dict_in
 
 def compare_uri(uri1: str, uri2: str) -> bool:
     """
@@ -66,10 +76,4 @@ def compare_uri(uri1: str, uri2: str) -> bool:
     :param uri2:
     :return:
     """
-    # first remove any protocol
-    if '://' in uri1: uri1 = uri1.split('://')[1]
-    if '://' in uri2: uri2 = uri2.split('://')[1]
-
-    uri1_segments: [str] = re.findall(r"[\w']+", uri1)
-    uri2_segments: [str] = re.findall(r"[\w']+", uri2)
-    return uri1_segments == uri2_segments
+    return normalise_uri(uri1) == normalise_uri(uri2)


### PR DESCRIPTION
namespace to taxonomy look up recursion replaced with fast LUT

**before**

**2 758 449** function calls (2647063 primitive calls) in **1.893 seconds**
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   419944    0.802    0.000    0.802    0.000 {method 'findall' of 're.Pattern' objects}    **--> bottleneck** 
   209962    0.187    0.000    1.364    0.000 uri_helper.py:58(compare_uri)    **--> bottleneck** 
   420027    0.130    0.000    0.209    0.000 re.py:271(_compile)
   419924    0.124    0.000    1.109    0.000 re.py:215(findall)
105789/2126    0.119    0.000    1.483    0.001 taxonomy.py:170(get_taxonomy)

**after**

**587 655** function calls (493573 primitive calls) in **0.496 seconds**
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
       21    0.110    0.005    0.110    0.005 {method '_parse_whole' of 'xml.etree.ElementTree.XMLParser' objects}   **--> bottleneck** 
    17486    0.044    0.000    0.044    0.000 {method 'sub' of 're.Pattern' objects}
     15/1    0.040    0.003    0.295    0.295 taxonomy.py:223(parse_taxonomy)
86870/511    0.036    0.000    0.043    0.000 taxonomy.py:170(get_taxonomy_LUT)

Takes lot less time and stack. Functionality unchanged. Tests pass.