### PR TITLE
Fix mypy None handling in EDGAR taxonomy namespace parsing

### DIFF
--- a/xbrl/taxonomy.py
+++ b/xbrl/taxonomy.py
@@ -253,8 +253,12 @@ class TaxonomyParser:
             href_el = loc.find("Href")
 
             if namespace_el is not None and href_el is not None:
-                namespace = namespace_el.text.strip()
-                href = href_el.text.strip()
+                namespace_text = namespace_el.text
+                href_text = href_el.text
+                if namespace_text is None or href_text is None:
+                    continue
+                namespace = namespace_text.strip()
+                href = href_text.strip()
                 self.global_ns_map[namespace] = href
 
     def _add_to_cache(self, schema_path: str, taxonomy: TaxonomySchema):


### PR DESCRIPTION
## Summary
- Add `None` guards for `Namespace` and `Href` element text in `_add_edgar_taxonomies`.
- Skip malformed `Loc` entries where either text value is missing.

## Why
- Fixes mypy `union-attr` errors caused by calling `.strip()` on `str | None` values.
- Keeps parsing robust when EDGAR taxonomy XML nodes are incomplete.

## Validation
- `ruff check xbrl`
- `ruff format --check xbrl`
- `mypy xbrl --check-untyped-defs`
- `pytest tests/`
