### PR TITLE
Raise a TransformationException for malformed date values

### DIFF
--- a/tests/test_transformation.py
+++ b/tests/test_transformation.py
@@ -319,5 +319,39 @@ class TransformationTest(unittest.TestCase):
                     )
 
 
+class MalformedValueTest(unittest.TestCase):
+    """A malformed fact must not abort the parse of an entire filing.
+
+    The date rules split the value and index the pieces positionally, so a value
+    with too few parts used to raise a bare IndexError, which escapes the
+    library's exception hierarchy and is not caught by instance.py.
+    """
+
+    NAMESPACE = "http://www.xbrl.org/inlineXBRL/transformation/2020-02-12"
+
+    MALFORMED = [
+        ("date-monthname-day-year-en", "September"),
+        ("date-day-monthname-year-en", "15"),
+        ("date-month-day-year-en", "9"),
+        ("date-monthname-year-en", "September"),
+    ]
+
+    WELL_FORMED = [
+        ("date-monthname-day-year-en", "September 15, 2025", "2025-09-15"),
+        ("date-day-monthname-year-en", "15 September 2025", "2025-09-15"),
+    ]
+
+    def test_malformed_value_raises_transformation_exception(self):
+        for format_code, value in self.MALFORMED:
+            with self.subTest(format=format_code, value=value):
+                with self.assertRaises(TransformationException):
+                    normalize(self.NAMESPACE, format_code, value)
+
+    def test_well_formed_values_are_unaffected(self):
+        for format_code, value, expected in self.WELL_FORMED:
+            with self.subTest(format=format_code, value=value):
+                self.assertEqual(normalize(self.NAMESPACE, format_code, value), expected)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/xbrl/transformations/__init__.py
+++ b/xbrl/transformations/__init__.py
@@ -605,6 +605,15 @@ def normalize(namespace: str, formatCode: str, value: str) -> str:
             raise RegistryNotSupported(namespace)
     except KeyError:
         raise InvalidTransformation(namespace, formatCode)
+    except IndexError:
+        # The date rules split the value and index the pieces positionally, so a
+        # value with fewer parts than the rule expects raises IndexError. Report
+        # it as a transformation failure: callers already handle that, whereas a
+        # bare IndexError escapes the library's exception hierarchy and aborts
+        # the parse of an entire filing over one malformed fact.
+        raise TransformationException(
+            f'Could not normalize "{value}" with the transformation rule "{formatCode}" of registry {namespace}'
+        )
     except TransformationNotImplemented:
         msg = f'The transformation "{formatCode}" rule of registry {namespace} is currently not implemented in py-xbrl'
         raise TransformationNotImplemented(msg)


### PR DESCRIPTION
Closes #139.

```python
>>> normalize("http://www.xbrl.org/inlineXBRL/transformation/2020-02-12",
...           "date-monthname-day-year-en", "September")
IndexError: list index out of range
```

The date rules do `seg = re.split(...)` and then index `seg[0]`, `seg[1]`, `seg[2]` positionally, so a value with fewer parts than the rule expects raises `IndexError`. That is outside the library's own exception hierarchy, so `instance.py` does not catch it and a single malformed fact aborts the parse of the entire filing.

**This is wider than the two functions named in the issue.** The same unguarded positional indexing appears in roughly twenty date rules across the module — `date-day-month-en`, `date-month-day-year-en`, `date-monthname-year-en` and so on all fail the same way. So rather than guard each function, `normalize()` converts `IndexError` into `TransformationException`, which fixes all of them in one place and keeps the rules themselves untouched.

That exception type is deliberate: `instance.py` already has

```python
except TransformationException:
    logging.warning(f'Could not transform value "{fact_value}" with format {fact_format}')
    return fact_value
```

so with this change a non-conformant fact degrades to a warning and the untransformed value, and the rest of the filing parses — which matches what you said on #161 about wanting to catch this.

```
before:  date-monthname-day-year-en  'September'  -> IndexError          (escapes, parse aborts)
after:   date-monthname-day-year-en  'September'  -> TransformationException (logged, parse continues)
         date-monthname-day-year-en  'September 15, 2025' -> '2025-09-15'   (unchanged)
```

**Tests.** Added `MalformedValueTest` to `tests/test_transformation.py`: four malformed values across four different rules must raise `TransformationException`, and two well-formed values must still transform correctly. Reverting the source while keeping the tests fails the malformed cases; the well-formed test passes either way, deliberately, so it catches over-correction. `test_transformation.py` and `test_uri_helper.py` are 5 passed / 6 subtests.

One thing I noticed but did not change, in case you want it separately: the existing `except KeyError` in `normalize()` conflates two different failures. It is there to catch an unknown `formatCode` in the registry dict, but it also swallows a `KeyError` from `monthNorm[seg[1]]` when a month name is unrecognised, reporting a malformed *value* as an invalid *transformation rule*. Happy to send a follow-up that separates them.
