### PR TITLE
Stabilize CI with current tools and deterministic tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,10 @@ include = ["xbrl*"]
 [tool.ruff]
 line-length = 120  # Increased from default 88 to allow longer lines
 
+[tool.ruff.lint]
+# Ruff 0.16 expanded its defaults; keep CI on the project's established rule set.
+select = ["E4", "E7", "E9", "F"]
+
 [tool.ruff.format]
 # Keep more compact formatting for simple expressions
 skip-magic-trailing-comma = true

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,66 +1,65 @@
-"""
-This is just a very simple unit test, that checks if the HttpCache is able to download a file, save it in the
-specified cache directory and serves it from there.
-"""
+"""Deterministic unit tests for HTTP caching and request pacing."""
 
-import logging
 import os
-import sys
 import tempfile
-import time
 import unittest
+from unittest.mock import Mock, call, patch
 
 from xbrl.cache import HttpCache
+from xbrl.helper.connection_manager import ConnectionManager
 
 
 class CacheHelperTest(unittest.TestCase):
-    def test_cache_file(self):
-        """
-        Unit test for CacheHelper.cache_file
-        :return:
-        """
-        logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+    def test_cache_file_downloads_then_serves_cached_content(self):
         with tempfile.TemporaryDirectory(prefix="py-xbrl-cache-test-") as tmp_cache_dir:
             cache_dir: str = os.path.join(tmp_cache_dir, "")
-            delay: int = 5000
-            cache: HttpCache = HttpCache(cache_dir, delay)
+            cache = HttpCache(cache_dir, delay=0)
+            test_url = "https://example.test/xml/note.xml"
+            expected_path = os.path.join(cache_dir, "example.test", "xml", "note.xml")
+            response_content = b"<note><body>cached response</body></note>"
+            response = Mock(status_code=200, content=response_content)
 
-            test_url: str = "https://www.w3schools.com/xml/note.xml"
-            expected_path: str = os.path.join(cache_dir, "www.w3schools.com", "xml", "note.xml")
+            with patch.object(cache.connection_manager, "download", return_value=response) as download:
+                self.assertEqual(cache.cache_file(test_url), expected_path)
+                self.assertEqual(download.call_count, 1)
+                self.assertEqual(cache.cache_file(test_url), expected_path)
+                self.assertEqual(download.call_count, 1)
 
-            # if the testing file already exists delete if first
-            if os.path.isfile(expected_path):
-                os.remove(expected_path)
+                self.assertTrue(cache.purge_file(test_url))
+                self.assertEqual(cache.cache_file(test_url), expected_path)
+                self.assertEqual(download.call_count, 2)
 
-            # on the first execution the file will be downloaded from the internet, no delay for first download
-            time_stamp: float = time.time()
-            self.assertEqual(cache.cache_file(test_url), expected_path)
-            time_delta = time.time() - time_stamp
-            self.assertLess(time_delta, delay / 1000)
-            logging.info(f"Time delta for first download: {time_delta}ms")
-
-            # delete the file and download it again to check if the delay for the second download is working
-            self.assertTrue(cache.purge_file(test_url))
-
-            time_stamp: float = time.time()
-            self.assertEqual(cache.cache_file(test_url), expected_path)
-            time_delta = time.time() - time_stamp
-            self.assertGreaterEqual(time_delta, delay / 1000)
-            logging.info(f"Time delta for second download: {time_delta}ms")
-
-            # now that the file is cached on the hard drive, the file path should be returned immediately
-            time_stamp = time.time()
-            self.assertEqual(cache.cache_file(test_url), expected_path)
-            time_delta = time.time() - time_stamp
-            self.assertLess(time_delta, delay / 1000)
-            logging.info(f"Time delta for third download: {time_delta}ms")
-
-            # test if the file was downloaded
+            self.assertEqual(download.call_args_list, [call(test_url, headers={}), call(test_url, headers={})])
             self.assertTrue(os.path.isfile(expected_path))
-            # delete the file
+            with open(expected_path, "rb") as cached_file:
+                self.assertEqual(cached_file.read(), response_content)
             self.assertTrue(cache.purge_file(test_url))
-            # test if the file was deleted
             self.assertFalse(os.path.isfile(expected_path))
+
+
+class ConnectionManagerTest(unittest.TestCase):
+    def test_rate_limit_delay_is_applied_before_follow_up_download(self):
+        manager = ConnectionManager(delay=5000, logs=False)
+        manager.next_try_systime_ms = 1000
+        test_url = "https://example.test/xml/note.xml"
+        response = Mock(status_code=200)
+
+        with (
+            patch.object(manager, "_get_systime_ms", side_effect=[1000, 1000, 1000, 1000]),
+            patch.object(manager._session, "get", return_value=response) as request,
+            patch("xbrl.helper.connection_manager.time.sleep") as sleep,
+        ):
+            self.assertIs(manager.download(test_url, headers={}), response)
+            self.assertIs(manager.download(test_url, headers={}), response)
+
+        self.assertEqual(sleep.call_args_list, [call(0.0), call(5.0)])
+        self.assertEqual(
+            request.call_args_list,
+            [
+                call(test_url, headers={}, allow_redirects=True, verify=True),
+                call(test_url, headers={}, allow_redirects=True, verify=True),
+            ],
+        )
 
 
 if __name__ == "__main__":

--- a/xbrl/helper/xml_parser.py
+++ b/xbrl/helper/xml_parser.py
@@ -6,6 +6,7 @@ It is used by the different parsing modules.
 
 import xml.etree.ElementTree as ET
 from io import StringIO
+from typing import Literal, cast
 from weakref import WeakKeyDictionary
 
 # Global storage for namespace maps, keyed by Element objects
@@ -38,7 +39,7 @@ def parse_file(file: str | StringIO) -> ET.ElementTree:
     :param file: either the file path (str) or a file-like object
     :return: The parsed ElementTree
     """
-    events = "start", "start-ns", "end-ns"
+    events: tuple[Literal["start", "start-ns", "end-ns"], ...] = "start", "start-ns", "end-ns"
 
     root = None
     ns_map: list[tuple[str, str]] = []
@@ -46,7 +47,7 @@ def parse_file(file: str | StringIO) -> ET.ElementTree:
     for event, elem in ET.iterparse(file, events):
         if event == "start-ns":
             # elem is a tuple[str, str] when event is "start-ns"
-            ns_map.append(elem)  # type: ignore[arg-type]
+            ns_map.append(cast(tuple[str, str], elem))
         elif event == "end-ns":
             ns_map.pop()
         elif event == "start":


### PR DESCRIPTION
## Summary

- Replace the external W3Schools cache test with deterministic cache-lifecycle and request-pacing coverage.
- Make the established Ruff rule set explicit so Ruff 0.16 does not silently enable hundreds of additional checks.
- Give ElementTree iterparse events an explicit literal type and use a cast accepted by both existing and current mypy releases.
- Keep production behavior unchanged.

## Why

Current unpinned development dependencies exposed three CI failures at once. Ruff 0.16 expanded its default rule set, mypy 2.3 tightened ElementTree event typing, and the third-party W3Schools endpoint now returns HTTP 403 from both local and GitHub runners.

The test and tooling changes are combined because neither isolated PR could become green on the current main branch: the deterministic-test branch was blocked by Ruff and mypy, while the tooling branch was blocked by the external test.

## Validation

- Ruff 0.16.2: ruff check xbrl
- Ruff 0.16.2: ruff format --check xbrl
- mypy 2.3.0: mypy xbrl --check-untyped-defs
- pytest -q tests/ — 12 passed, 6 subtests passed
- Ruff 0.14.5: ruff check xbrl/helper/xml_parser.py tests/test_cache.py
- Ruff 0.14.5: ruff format --check xbrl/helper/xml_parser.py tests/test_cache.py
- mypy 1.19.1: mypy xbrl/helper/xml_parser.py tests/test_cache.py --check-untyped-defs
- pytest -q tests/test_cache.py — 2 passed